### PR TITLE
FIX dirkhillbrecht/UiUiUi#13

### DIFF
--- a/src/UIHorizontalLine.cpp
+++ b/src/UIHorizontalLine.cpp
@@ -35,7 +35,7 @@ UIArea* UIHorizontalLine::render(U8G2 *display,bool force) {
 
 /* The preferred size of a line is 1+2*border in height and "as wide as possible" */
 void UIHorizontalLine::computePreferredSize(U8G2 *display,UISize *preferredSize) {
-  preferredSize->set(UISize::MAX_LEN,2*border+1);
+  preferredSize->set(0,2*border+1);
 }
 
 // end of file

--- a/src/UIVerticalLine.cpp
+++ b/src/UIVerticalLine.cpp
@@ -32,7 +32,7 @@ UIArea* UIVerticalLine::render(U8G2 *display,bool force) {
 
 /* The preferred size of a line is 1+2*border in width and "as high as possible" */
 void UIVerticalLine::computePreferredSize(U8G2 *display,UISize *preferredSize) {
-  preferredSize->set(2*border+1,UISize::MAX_LEN);
+  preferredSize->set(2*border+1,0);
 }
 
 // end of file


### PR DESCRIPTION
By requesting '0' space in the axial direction, the lines will never force a group to request more space than the bare minimum it needs.